### PR TITLE
Setup gallery MVP

### DIFF
--- a/src/App/Category-Breadcrumb/category-breadcrumb.spec.js
+++ b/src/App/Category-Breadcrumb/category-breadcrumb.spec.js
@@ -9,22 +9,16 @@ import { Container } from './category-breadcrumb.style.js';
 describe('CategoryBreadcrumb Component', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(<CategoryBreadcrumb />);
-  });
-
-  it('should render correctly with no props', () => {
-    expect(wrapper.find(Container)).toHaveLength(1);
+    wrapper = shallow(<CategoryBreadcrumb category="example" />);
   });
 
   it('should render correctly with props', () => {
-    wrapper.setProps({ category: 'example' });
     expect(wrapper.find(Container)).toHaveLength(1);
   });
 
   it('should render correct category with capital letter', () => {
     const string = 'example';
     const capitalStr = `${string[0].toUpperCase()}${string.slice(1)}`;
-    wrapper.setProps({ category: string });
     expect(wrapper.find('a').text()).toEqual(`${capitalStr}`);
   });
 });

--- a/src/App/Gallery/Gallery-Image/Gallery-Image.jsx
+++ b/src/App/Gallery/Gallery-Image/Gallery-Image.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Container } from './Gallery-Image.style';
+
+export default () => {
+  const text = 'gallery image goes here';
+  return (
+    <Container>
+      <div>
+        {text}
+      </div>
+    </Container>
+  );
+};

--- a/src/App/Gallery/Gallery-Image/Gallery-Image.jsx
+++ b/src/App/Gallery/Gallery-Image/Gallery-Image.jsx
@@ -1,14 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { Container } from './Gallery-Image.style';
 
-export default () => {
-  const text = 'gallery image goes here';
-  return (
-    <Container>
-      <div>
-        {text}
-      </div>
-    </Container>
-  );
+const GalleryImage = ({ image }) => (
+  <Container>
+    <div>
+      <img src={image} alt="example" />
+    </div>
+  </Container>
+);
+
+GalleryImage.propTypes = {
+  image: PropTypes.string.isRequired,
 };
+
+export default GalleryImage;

--- a/src/App/Gallery/Gallery-Image/Gallery-Image.spec.js
+++ b/src/App/Gallery/Gallery-Image/Gallery-Image.spec.js
@@ -1,0 +1,27 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable import/extensions */
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+import GalleryImage from './Gallery-Image';
+
+describe('GalleryImage Component', () => {
+  let wrapper;
+  const requiredProps = {
+    image: 'http://lorempixel.com/400/200/',
+  };
+  beforeEach(() => {
+    wrapper = shallow(<GalleryImage
+      image={requiredProps.image}
+    />);
+  });
+
+  it('should render correctly with image props.image src', () => {
+    expect(
+      wrapper
+        .find('img')
+        .props().src,
+    )
+      .toEqual(requiredProps.image);
+  });
+});

--- a/src/App/Gallery/Gallery-Image/Gallery-Image.style.js
+++ b/src/App/Gallery/Gallery-Image/Gallery-Image.style.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+// eslint-disable-next-line import/prefer-default-export
+export const Container = styled.div`
+  width: 82%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border: solid red 1px;
+`;

--- a/src/App/Gallery/Gallery-Image/Gallery-Image.style.js
+++ b/src/App/Gallery/Gallery-Image/Gallery-Image.style.js
@@ -6,5 +6,7 @@ export const Container = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  border: solid red 1px;
+  img {
+    max-width: 100%;
+  }
 `;

--- a/src/App/Gallery/Gallery-Picker/Gallery-Picker.jsx
+++ b/src/App/Gallery/Gallery-Picker/Gallery-Picker.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Container } from './Gallery-Picker.style';
+
+export default () => {
+  const text = 'Gallery Picker Goes here';
+  return (
+    <Container>
+      <div>
+        {text}
+      </div>
+    </Container>
+  );
+};

--- a/src/App/Gallery/Gallery-Picker/Gallery-Picker.jsx
+++ b/src/App/Gallery/Gallery-Picker/Gallery-Picker.jsx
@@ -1,14 +1,33 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { Container } from './Gallery-Picker.style';
 
-export default () => {
-  const text = 'Gallery Picker Goes here';
+const GalleryPicker = ({ images, handleImageHover }) => {
+  const imagesDivs = images.map((value, index) => (
+    <div key={value}>
+      <img
+        onMouseOver={handleImageHover}
+        onFocus={handleImageHover}
+        id={`pickerImage-${index}`}
+        className="pickerImage"
+        src={value}
+        alt={`${index}`}
+      />
+    </div>
+  ));
   return (
     <Container>
-      <div>
-        {text}
-      </div>
+      {imagesDivs}
     </Container>
   );
 };
+
+GalleryPicker.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.string).isRequired,
+  handleImageHover: PropTypes.func.isRequired,
+};
+
+export default GalleryPicker;

--- a/src/App/Gallery/Gallery-Picker/Gallery-Picker.spec.js
+++ b/src/App/Gallery/Gallery-Picker/Gallery-Picker.spec.js
@@ -10,7 +10,7 @@ describe('GalleryPicker Component', () => {
   let wrapper;
   let testVar = false;
   const requiredProps = {
-    images: ['test', 'test', 'test'],
+    images: ['http://lorempixel.com/400/200/', 'http://lorempixel.com/400/200/', 'http://lorempixel.com/400/200/'],
     handleImageHover: () => {
       testVar = true;
       return true;

--- a/src/App/Gallery/Gallery-Picker/Gallery-Picker.spec.js
+++ b/src/App/Gallery/Gallery-Picker/Gallery-Picker.spec.js
@@ -1,0 +1,46 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable import/extensions */
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+import GalleryPicker from './Gallery-Picker';
+import { Container } from './Gallery-Picker.style';
+
+describe('GalleryPicker Component', () => {
+  let wrapper;
+  let testVar = false;
+  const requiredProps = {
+    images: ['test', 'test', 'test'],
+    handleImageHover: () => {
+      testVar = true;
+      return true;
+    },
+  };
+  beforeEach(() => {
+    wrapper = shallow(<GalleryPicker
+      images={requiredProps.images}
+      handleImageHover={requiredProps.handleImageHover}
+    />);
+  });
+
+  it('should render correctly with props.images of length 3', () => {
+    expect(
+      wrapper
+        .find(Container)
+        .children(),
+    )
+      .toHaveLength(requiredProps.images.length);
+  });
+
+  it('should correctly activate onMouseOver Handler', () => {
+    wrapper.find('img#pickerImage-0').simulate('mouseover');
+    expect(testVar).toEqual(true);
+    testVar = false;
+  });
+
+  it('should correctly activate onFocus Handler', () => {
+    wrapper.find('img#pickerImage-0').simulate('focus');
+    expect(testVar).toEqual(true);
+    testVar = false;
+  });
+});

--- a/src/App/Gallery/Gallery-Picker/Gallery-Picker.style.js
+++ b/src/App/Gallery/Gallery-Picker/Gallery-Picker.style.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+// eslint-disable-next-line import/prefer-default-export
+export const Container = styled.div`
+  width: 15%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border: solid red 1px;
+`;

--- a/src/App/Gallery/Gallery-Picker/Gallery-Picker.style.js
+++ b/src/App/Gallery/Gallery-Picker/Gallery-Picker.style.js
@@ -6,5 +6,22 @@ export const Container = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  border: solid red 1px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  img {
+    cursor: pointer;
+    border-radius: 2px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    width: 95%;
+    border: .5px solid black;
+  }
+  img:hover {
+    border-color: #e77600;
+    box-shadow: 0px 0px 2px 1px #e77600;
+  }
+  img.selected {
+    border-color: #e77600;
+    box-shadow: 0px 0px 2px 1px #e77600;
+  }
 `;

--- a/src/App/Gallery/gallery.jsx
+++ b/src/App/Gallery/gallery.jsx
@@ -1,3 +1,4 @@
+/* eslint-env browser */
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -12,14 +13,35 @@ export default class Gallery extends React.Component {
     this.state = {
       currentImg: props.images[0],
     };
+
+    this.handleImageHover = this.handleImageHover.bind(this);
+  }
+
+  handleImageHover(event) {
+    const selectedImageId = event.target.id.split('-')[1];
+    const images = document.querySelectorAll('img.pickerImage');
+    images.forEach((image) => {
+      if (image.id.split('-')[1] === selectedImageId) {
+        this.setState({
+          currentImg: image.src,
+        });
+      }
+      image.classList.toggle('selected', image.id.split('-')[1] === selectedImageId);
+    });
   }
 
   render() {
     const { currentImg } = this.state;
     const { images } = this.props;
+    if (images.length === 1) {
+      images.push('https://s3.us-east-2.amazonaws.com/product-summary-component/electronics2.jpg');
+    }
     return (
       <Container>
-        <GalleryPicker images={images} />
+        <GalleryPicker
+          images={images}
+          handleImageHover={this.handleImageHover}
+        />
         <GalleryImage image={currentImg} />
       </Container>
     );

--- a/src/App/Gallery/gallery.jsx
+++ b/src/App/Gallery/gallery.jsx
@@ -1,9 +1,31 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { Container } from './gallery.style';
+import GalleryImage from './Gallery-Image/Gallery-Image';
+import GalleryPicker from './Gallery-Picker/Gallery-Picker';
 
-export default () => (
-  <Container>
-    Gallery Comp
-  </Container>
-);
+export default class Gallery extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentImg: props.images[0],
+    };
+  }
+
+  render() {
+    const { currentImg } = this.state;
+    const { images } = this.props;
+    return (
+      <Container>
+        <GalleryPicker images={images} />
+        <GalleryImage image={currentImg} />
+      </Container>
+    );
+  }
+}
+
+Gallery.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+};

--- a/src/App/Gallery/gallery.spec.js
+++ b/src/App/Gallery/gallery.spec.js
@@ -1,13 +1,20 @@
 /* eslint-disable react/jsx-filename-extension */
-/* eslint-disable import/extensions */
 /* eslint-env jest */
 import React from 'react';
 import { shallow } from 'enzyme';
-import Gallery from './gallery.jsx';
+import Gallery from './gallery';
+import { Container } from './gallery.style';
 
 describe('Gallery Component', () => {
-  it('should render correctly with no props', () => {
-    const component = shallow(<Gallery />);
-    expect(component).toMatchSnapshot();
+  let wrapper;
+  const requiredProps = {
+    images: ['test', 'test', 'test'],
+    handleImageHover: () => {},
+  };
+  beforeEach(() => {
+    wrapper = shallow(<Gallery images={requiredProps.images} />);
+  });
+  it('should render correctly with required props', () => {
+    expect(wrapper.find(Container).children()).toHaveLength(2);
   });
 });

--- a/src/App/Gallery/gallery.style.js
+++ b/src/App/Gallery/gallery.style.js
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 // eslint-disable-next-line import/prefer-default-export
 export const Container = styled.div`
-  width: 48%;
+  width: 45%;
   min-height: 500px;
   display: flex;
-  flex-direction: column;
-  border: solid red 2px;
+  flex-direction: row;
+  justify-content: space-between;
 `;

--- a/src/App/Summary/summary.jsx
+++ b/src/App/Summary/summary.jsx
@@ -61,7 +61,7 @@ const Summary = ({ product }) => {
           <p>
             {'Pay '}
             { priceStrikeThrough }
-            {` ${product.price - 10.01} after using available Discover Cashback Bonus®.`}
+            {` $${product.price - 10.01} after using available Discover Cashback Bonus®.`}
           </p>
         </div>
       </Price>

--- a/src/App/Summary/summary.style.js
+++ b/src/App/Summary/summary.style.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 // eslint-disable-next-line import/prefer-default-export
 export const Container = styled.div`
-  width: 48%;
+  width: 53%;
   min-height: 500px;
   display: flex;
   flex-direction: column;

--- a/src/App/app.jsx
+++ b/src/App/app.jsx
@@ -13,7 +13,24 @@ export default class App extends React.Component {
     super(props);
     this.state = {
       product: {
-        name: 'test',
+        id: 1,
+        unique_id: 1,
+        name: 'Amazon Product 1',
+        category: 'electronics',
+        manufacturer: 'Murazik and Sons',
+        primary_image: 'https://s3.us-east-2.amazonaws.com/product-summary-component/electronics1.jpg',
+        review_one_star_count: 624,
+        review_two_star_count: 639,
+        review_three_star_count: 622,
+        review_four_star_count: 275,
+        review_five_star_count: 251,
+        review_count: 2411,
+        question_count: 216,
+        price: 561,
+        total_price: 571,
+        stock: 5,
+        is_prime: true,
+        description: 'string',
       },
     };
   }
@@ -44,7 +61,7 @@ export default class App extends React.Component {
           category={product.category}
         />
         <RowContainer>
-          <Gallery />
+          <Gallery images={[product.primary_image]} />
           <Summary
             product={product}
           />

--- a/src/App/app.style.js
+++ b/src/App/app.style.js
@@ -11,7 +11,6 @@ export const ColContainer = styled.div`
 export const RowContainer = styled.div`
   width: 98%;
   height: 90%;
-  padding-top: 10px;
   padding-bottom: 10px;
   display: flex;
   flex-direction: row;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,9 @@ module.exports = {
     publicPath: '/',
     filename: 'bundle.js',
   },
+  resolve: {
+    extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx'],
+  },
   devServer: {
     contentBase: './dist',
     historyApiFallback: true,


### PR DESCRIPTION
# Test Results
![screen shot 2019-02-14 at 2 49 24 pm](https://user-images.githubusercontent.com/13230506/52822952-1e06b980-3068-11e9-820a-85049e5b41a5.png)
![screen shot 2019-02-14 at 2 49 34 pm](https://user-images.githubusercontent.com/13230506/52822938-0fb89d80-3068-11e9-8732-4d554694c1f8.png)
![screen shot 2019-02-14 at 2 49 43 pm](https://user-images.githubusercontent.com/13230506/52822939-0fb89d80-3068-11e9-9634-f5ecb526a8e6.png)
![screen shot 2019-02-14 at 2 49 50 pm](https://user-images.githubusercontent.com/13230506/52822940-10513400-3068-11e9-8782-ea980022f669.png)

# Summary
Setup up Gallery Comp with 2 Children Comps (Gallery Picker & Gallery Image)
 * Gallery Picker allows user to select images by hover over their thumbnails, and updates the state store in Gallery Comp
 * Gallery Image simply displays the selected image stored in the Gallery Comps states

# Demo
![amazon product gallery gif](https://user-images.githubusercontent.com/13230506/52823054-805fba00-3068-11e9-84a0-cf89e475c03c.gif)

